### PR TITLE
fix: prevent merge conflicts with rebase-first workflow

### DIFF
--- a/dev/git-agent.md
+++ b/dev/git-agent.md
@@ -1,52 +1,115 @@
 # Agent Git (développeur)
 
 ## Rôle
-Assister dans les opérations git courantes.
-Conventions et protocole complet dans `rules/git-workflow.md`.
-La protection de `main` est assurée par GitHub (branch ruleset).
+Assister dans les opérations git. Conventions complètes dans `rules/git-workflow.md`.
+Protection de `main` assurée par GitHub (branch ruleset).
+
+---
 
 ## Avant toute modification de code ou d'agent
 
 Avant de toucher à un fichier `.py`, `.md` (hors `data/`), `.json` :
 
 ```bash
+git fetch origin
 git branch -a
 git status
 ```
 
 Demander à l'utilisateur :
 > "Sur quelle branche veux-tu travailler ?
+> Branches disponibles : [liste]
 > → Continuer sur une branche existante
 > → Créer une nouvelle branche"
 
-Nouvelle branche → toujours depuis `main` :
+**Vérification anti-conflit avant de créer une nouvelle branche :**
+Si des PRs sont ouvertes qui touchent à `CLAUDE.md`, `agents/`, `rules/`, `dev/` → signaler et recommander de les merger d'abord.
+
+**Nouvelle branche — toujours depuis main à jour :**
 ```bash
 git checkout main
 git pull origin main
 git checkout -b feature/YYYY-MM-DD-sujet
 ```
 
+---
+
 ## Commit
 
+Afficher le diff avant de stager :
 ```bash
-git status
 git diff --stat
-git add scripts/ agents/ rules/ dev/ hooks/ CLAUDE.md README.md requirements.txt .gitignore .env.example .gitattributes .claude/settings.json data/.gitkeep data/*.example.md
+git status
+```
+
+Stager uniquement les fichiers autorisés (jamais `git add -A`) :
+```bash
+git add scripts/ agents/ rules/ dev/ hooks/ CLAUDE.md README.md \
+        requirements.txt .gitignore .env.example .gitattributes \
+        .claude/settings.json data/.gitkeep data/*.example.md
 git commit -m "type: description courte"
 ```
 
-## Push + Pull Request
+---
+
+## Push — rebase obligatoire avant chaque push
 
 ```bash
-git push origin nom-de-la-branche
+git fetch origin
+git rebase origin/main
+```
+
+Si conflits pendant le rebase :
+```bash
+# Résoudre les fichiers en conflit, puis :
+git add <fichier-résolu>
+git rebase --continue
+# Pour annuler : git rebase --abort
+```
+
+**Pousser après le rebase :**
+```bash
+# Premier push de la branche :
+git push -u origin nom-de-la-branche
+
+# Après un rebase (historique modifié) :
+git push --force-with-lease origin nom-de-la-branche
+```
+
+> `--force-with-lease` refuse d'écraser si quelqu'un d'autre a pushé entre-temps.
+
+---
+
+## Après merge d'une PR
+
+Toujours nettoyer :
+```bash
+git checkout main
+git pull origin main
+git branch -d nom-de-la-branche
+```
+
+---
+
+## Pull Request
+
+Sur demande explicite uniquement :
+```bash
 gh pr create --title "titre" --body "description"
 ```
+
+- Toujours cibler `main`
+- Vérifier qu'aucune autre PR ouverte ne touche aux mêmes fichiers
+- Ne jamais merger sans validation explicite de l'utilisateur
+
+---
 
 ## Commandes utiles
 
 ```bash
-git log --oneline -10    # Historique
-git branch -a            # Toutes les branches
-git diff --stat          # Résumé des changements
-gh pr list               # PRs ouvertes
+git log --oneline --graph -10    # Historique visuel
+git branch -a                    # Toutes les branches
+git diff --stat                  # Résumé des changements
+git stash                        # Mettre de côté les changements
+git rebase --abort               # Annuler un rebase en cours
 ```

--- a/hooks/pre-push.py
+++ b/hooks/pre-push.py
@@ -1,9 +1,12 @@
 """
 Hook PreToolUse (Bash) — intercepte les commandes git push.
-Scanne les fichiers committés et bloque si des données personnelles sont détectées.
+
+Vérifie deux choses :
+1. Aucune donnée personnelle dans les fichiers committés
+2. La branche n'a pas divergé de origin/main (risque de conflit)
 
 Exit code 0 → push autorisé
-Exit code 2 → push bloqué (Claude ne peut pas exécuter la commande)
+Exit code 2 → push bloqué
 """
 import os
 import sys
@@ -20,42 +23,65 @@ BLOCKED_PATTERNS = [
 
 tool_input = os.environ.get("CLAUDE_TOOL_INPUT", "")
 
-# Ne s'active que si la commande contient "git push"
 if "git push" not in tool_input:
     sys.exit(0)
 
-# Récupère les fichiers du dernier commit + staged
+errors = []
+
+# --- Vérification 1 : données personnelles ---
 try:
-    result = subprocess.run(
+    committed = subprocess.run(
         ["git", "diff", "--name-only", "origin/main...HEAD"],
         capture_output=True, text=True
-    )
-    committed_files = result.stdout.strip().split("\n") if result.stdout.strip() else []
+    ).stdout.strip().split("\n")
 
-    staged_result = subprocess.run(
+    staged = subprocess.run(
         ["git", "diff", "--cached", "--name-only"],
         capture_output=True, text=True
-    )
-    staged_files = staged_result.stdout.strip().split("\n") if staged_result.stdout.strip() else []
+    ).stdout.strip().split("\n")
 
-    all_files = committed_files + staged_files
+    for f in committed + staged:
+        for pattern in BLOCKED_PATTERNS:
+            if pattern in f:
+                errors.append(f"  Donnee personnelle detectee : {f}")
+                break
 except Exception:
-    sys.exit(0)
+    pass
 
-violations = []
-for f in all_files:
-    for pattern in BLOCKED_PATTERNS:
-        if pattern in f:
-            violations.append(f)
-            break
+# --- Vérification 2 : divergence avec origin/main ---
+try:
+    subprocess.run(["git", "fetch", "origin", "main", "--quiet"],
+                   capture_output=True)
 
-if violations:
-    print("\n[SECURITE] Push bloque — donnees personnelles detectees :\n")
-    for v in violations:
-        print(f"  ❌  {v}")
-    print("\nRetire ces fichiers avant de pusher.")
-    print("Verifie ton .gitignore et utilise : git rm --cached <fichier>\n")
+    current_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True, text=True
+    ).stdout.strip()
+
+    behind = subprocess.run(
+        ["git", "log", "--oneline", "HEAD..origin/main"],
+        capture_output=True, text=True
+    ).stdout.strip()
+
+    if behind:
+        count = len([l for l in behind.split("\n") if l])
+        errors.append(
+            f"  Branche '{current_branch}' en retard de {count} commit(s) sur origin/main.\n"
+            f"  Rebase avant de pusher :\n"
+            f"    git rebase origin/main\n"
+            f"  Puis :\n"
+            f"    git push --force-with-lease origin {current_branch}"
+        )
+except Exception:
+    pass
+
+# --- Résultat ---
+if errors:
+    print("\n[SECURITE] Push bloque :\n")
+    for e in errors:
+        print(e)
+    print()
     sys.exit(2)
 
-print("[SECURITE] Verification OK — aucune donnee personnelle detectee.")
+print("[OK] Verification pre-push reussie.")
 sys.exit(0)

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -3,60 +3,73 @@
 ## Protection de main
 
 La branche `main` est protégée par GitHub (branch ruleset).
-**Aucun push direct n'est possible** — tout passe par une Pull Request.
-Cette règle est appliquée au niveau réseau par GitHub, indépendamment des règles locales.
+Aucun push direct — tout passe par une Pull Request.
 
-## Convention de nommage des branches
+---
 
-| Type | Format | Exemple |
-|------|--------|---------|
-| Nouvelle fonctionnalité | `feature/YYYY-MM-DD-sujet` | `feature/2026-04-25-nutrition-agent` |
-| Correction de bug | `fix/YYYY-MM-DD-sujet` | `fix/2026-04-25-strava-token` |
-| Mise à jour de règles | `rules/YYYY-MM-DD-sujet` | `rules/2026-04-25-recovery-thresholds` |
-| Mise à jour d'agent | `agent/YYYY-MM-DD-sujet` | `agent/2026-04-25-setup-flow` |
+## Règle fondamentale — une branche à la fois sur les fichiers partagés
 
-## Protocole avant toute modification de code ou d'agent
+Ces fichiers génèrent des conflits si modifiés sur plusieurs branches en parallèle :
+`CLAUDE.md` · `agents/*.md` · `rules/*.md` · `dev/*.md`
 
-**Déclencheur** : toute demande de modification sur `.py`, `.md` (hors `data/`), `.json`.
+**Avant de créer une nouvelle branche** : vérifier qu'aucune PR ouverte ne touche aux mêmes fichiers. Si oui → merger d'abord.
 
-### 1. Afficher les branches existantes
+---
+
+## Convention de nommage
+
+| Type | Format |
+|------|--------|
+| Nouvelle fonctionnalité | `feature/YYYY-MM-DD-sujet` |
+| Correction de bug | `fix/YYYY-MM-DD-sujet` |
+| Mise à jour de règles | `rules/YYYY-MM-DD-sujet` |
+| Mise à jour d'agent | `agent/YYYY-MM-DD-sujet` |
+
+---
+
+## Cycle de travail complet
+
+### 1. Créer une branche depuis main à jour
 ```bash
-git branch -a
-git status
-```
-
-### 2. Demander à l'utilisateur
-> "Sur quelle branche veux-tu travailler ?
-> Branches existantes : [liste]
-> → Continuer sur une branche existante
-> → Créer une nouvelle branche"
-
-### 3a. Branche existante
-```bash
-git checkout nom-de-la-branche
-```
-
-### 3b. Nouvelle branche — toujours depuis main
-```bash
+git fetch origin
 git checkout main
 git pull origin main
 git checkout -b feature/YYYY-MM-DD-sujet
 ```
 
-### 4. Confirmer avant de modifier
+### 2. Commiter
 ```bash
-git branch --show-current
+git add <fichiers spécifiques>
+git commit -m "type: description"
 ```
 
-## Cycle de travail
+### 3. Rebase avant chaque push (obligatoire)
+```bash
+git fetch origin
+git rebase origin/main
+```
 
+En cas de conflits :
+```bash
+# Résoudre → puis :
+git add <fichier>
+git rebase --continue
 ```
-1. Modifications sur la branche feature
-2. git add <fichiers spécifiques>   ← jamais git add -A
-3. git commit -m "type: description"
-4. git push origin nom-de-la-branche
-5. gh pr create (sur demande)       ← GitHub bloque le merge sans PR
+
+### 4. Pousser
+```bash
+git push -u origin nom-de-la-branche          # premier push
+git push --force-with-lease origin nom         # après un rebase
 ```
+
+### 5. Après merge de la PR
+```bash
+git checkout main
+git pull origin main
+git branch -d nom-de-la-branche
+```
+
+---
 
 ## Fichiers autorisés dans un commit
 
@@ -65,9 +78,7 @@ git branch --show-current
 | `scripts/*.py` | `.env` |
 | `agents/*.md` | `data/running.db` |
 | `rules/*.md` | `data/profile.md` |
-| `hooks/*.py` | `data/calendar.md` |
-| `CLAUDE.md` | `data/feedbacks.md` |
-| `README.md` | `.venv/` |
-| `.env.example` | `personal/` |
-| `data/*.example.md` | |
-| `data/.gitkeep` | |
+| `dev/*.md` | `data/calendar.md` |
+| `hooks/*.py` | `data/feedbacks.md` |
+| `CLAUDE.md` | `.venv/` · `personal/` |
+| `README.md` · `.env.example` | |


### PR DESCRIPTION
- hooks/pre-push.py: now blocks push if branch is behind origin/main, suggests git rebase origin/main + force-with-lease
- dev/git-agent.md: mandatory rebase before every push, anti-conflict check before creating new branch (warn if shared files touched)
- rules/git-workflow.md: rebase step explicit in cycle, one-branch-at-a-time rule for shared files (CLAUDE.md, agents/, rules/, dev/)